### PR TITLE
Upgrade analyzer, sdk, build runner, dart_style and source_gen

### DIFF
--- a/lib/src/builders/synthetic_builder.dart
+++ b/lib/src/builders/synthetic_builder.dart
@@ -30,7 +30,9 @@ abstract class SyntheticBuilder<S extends SyntheticInput> implements Builder {
     this.header = '',
     this.footer = '',
     Formatter? formatter,
-  })  : formatter = formatter ?? DartFormatter().format,
+  })  : formatter = formatter ??
+            DartFormatter(languageVersion: DartFormatter.latestLanguageVersion)
+                .format,
         syntheticInput = SyntheticInput.instance<S>();
 
   /// Input files. Specify the complete path relative to the
@@ -123,8 +125,8 @@ abstract class SyntheticBuilder<S extends SyntheticInput> implements Builder {
       // Read library.
       final library = await buildStep.resolver.libraryFor(assetId);
       // Get dependencies
-      for (final import in library.libraryImports) {
-        final uri = Uri.parse(import.uri.toString());
+      for (final import in library.importedLibraries) {
+        final uri = Uri.parse(import.source.uri.toString());
         // Skip if uri scheme is not "package" or "asset".
         if (uri.scheme == 'package' ||
             uri.scheme == 'asset' ||

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,23 +13,22 @@ topics:
   - build-runner
   - source-code-generator
 
-
-
 environment:
-  sdk: '^3.0.0'
+  sdk: '^3.6.0'
 
 dependencies:
-  analyzer: ^6.4.1
+  analyzer: ^7.0.0
   build: ^2.4.1
-  build_runner: ^2.4.9
-  dart_style: ^2.3.6
+  build_runner: ^2.4.14
+  dart_style: ^3.0.1
   directed_graph: ^0.4.3
   exception_templates: ^0.3.0
   file: ^7.0.0
   glob: ^2.1.2
   lazy_memo: ^0.2.3
   path: ^1.9.0
-  source_gen: ^1.5.0
+  source_gen: ^2.0.0
+
 #dependency_overrides:
 # source_gen:
 #   git:


### PR DESCRIPTION
The current version of merging_builder do not allow to update sdk, analyzer, etc on existing project.

This commit upgrade some dependencies and fix some code in SyntheticBuilder because some methods do not exists anymore after updagring deps.